### PR TITLE
Add env-based config loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,12 @@ cd sibotan-ai
 pip install -r requirements.txt
 ```
 
-### 3. Buat file `config.py`
-```python
-# config.py
-OPENAI_API_KEY = "your_openai_key"
-TV_USER = "your_tradingview_username"
-TV_PASS = "your_tradingview_password"
+### 3. Set environment variable
+Sebelum menjalankan program, pastikan variabel berikut sudah di-set pada environment Anda:
+```bash
+export OPENAI_API_KEY="your_openai_key"
+export TV_USER="your_tradingview_username"
+export TV_PASS="your_tradingview_password"
 ```
 
 ---

--- a/config.py
+++ b/config.py
@@ -1,7 +1,16 @@
+import os
 
-# config.py
-OPENAI_API_KEY = "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"
+OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
+TV_USER = os.getenv('TV_USER')
+TV_PASS = os.getenv('TV_PASS')
 
-# Login TradingView
-TV_USER = "sopeng2005@gmail.com"
-TV_PASS = "25Agustus2005@"
+required = {
+    'OPENAI_API_KEY': OPENAI_API_KEY,
+    'TV_USER': TV_USER,
+    'TV_PASS': TV_PASS,
+}
+missing = [name for name, value in required.items() if not value]
+if missing:
+    missing_vars = ', '.join(missing)
+    raise EnvironmentError(f"Missing required environment variable(s): {missing_vars}")
+


### PR DESCRIPTION
## Summary
- load settings from environment variables in `config.py`
- document required environment variables in README

## Testing
- `python -m py_compile config.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_684d3a8cd2bc832286f60b62dc556d51