### PR TITLE
Add credential storage and configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,12 @@ cd sibotan-ai
 pip install -r requirements.txt
 ```
 
-### 3. Set environment variable
-Sebelum menjalankan program, pastikan variabel berikut sudah di-set pada environment Anda:
+### 3. Konfigurasi kredensial
+Jalankan perintah berikut untuk memasukkan API key dan akun TradingView Anda:
 ```bash
-export OPENAI_API_KEY="your_openai_key"
-export TV_USER="your_tradingview_username"
-export TV_PASS="your_tradingview_password"
+python main.py --configure
 ```
+Perintah di atas akan menanyakan `OPENAI_API_KEY`, `TV_USER`, dan `TV_PASS` lalu menyimpannya ke file `credentials.json`.
 
 ---
 
@@ -57,6 +56,7 @@ export TV_PASS="your_tradingview_password"
 ```bash
 python main.py
 ```
+Gunakan opsi `--configure` kapan saja jika ingin mengganti API key atau akun TradingView yang tersimpan.
 
 ---
 

--- a/config.py
+++ b/config.py
@@ -1,16 +1,24 @@
 import os
+from credentials import load_credentials, save_credentials
 
-OPENAI_API_KEY = os.getenv('OPENAI_API_KEY')
-TV_USER = os.getenv('TV_USER')
-TV_PASS = os.getenv('TV_PASS')
+_creds = load_credentials()
+
+OPENAI_API_KEY = _creds.get('OPENAI_API_KEY') or os.getenv('OPENAI_API_KEY')
+TV_USER = _creds.get('TV_USER') or os.getenv('TV_USER')
+TV_PASS = _creds.get('TV_PASS') or os.getenv('TV_PASS')
 
 required = {
     'OPENAI_API_KEY': OPENAI_API_KEY,
     'TV_USER': TV_USER,
     'TV_PASS': TV_PASS,
 }
+
 missing = [name for name, value in required.items() if not value]
 if missing:
-    missing_vars = ', '.join(missing)
-    raise EnvironmentError(f"Missing required environment variable(s): {missing_vars}")
+    for name in missing:
+        required[name] = input(f'Enter {name}: ').strip()
+    save_credentials(required)
 
+OPENAI_API_KEY = required['OPENAI_API_KEY']
+TV_USER = required['TV_USER']
+TV_PASS = required['TV_PASS']

--- a/credentials.py
+++ b/credentials.py
@@ -1,0 +1,19 @@
+import json
+import os
+
+CRED_FILE = os.path.join(os.path.dirname(__file__), 'credentials.json')
+
+def load_credentials():
+    """Load credentials from JSON file."""
+    if not os.path.exists(CRED_FILE):
+        return {}
+    try:
+        with open(CRED_FILE, 'r') as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+def save_credentials(data):
+    """Save credentials to JSON file."""
+    with open(CRED_FILE, 'w') as f:
+        json.dump(data, f, indent=2)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 from tradingview_ta import TA_Handler, Interval, Exchange
 from tvDatafeed import TvDatafeed, Interval as TvInterval
-from config import OPENAI_API_KEY, TV_USER, TV_PASS
+from credentials import load_credentials, save_credentials
+import argparse
 import openai
 import pandas as pd
 import sys
@@ -15,6 +16,25 @@ import shutil
 
 # Inisialisasi colorama
 init(autoreset=True)
+
+# Parse CLI arguments
+parser = argparse.ArgumentParser(description="Sibotan Ai")
+parser.add_argument('--configure', action='store_true', help='Set or update saved credentials and exit')
+args = parser.parse_args()
+
+if args.configure:
+    creds = load_credentials()
+    creds['OPENAI_API_KEY'] = input('OPENAI_API_KEY: ').strip()
+    creds['TV_USER'] = input('TV_USER: ').strip()
+    creds['TV_PASS'] = input('TV_PASS: ').strip()
+    save_credentials(creds)
+    print('Credentials saved.')
+    sys.exit(0)
+
+import config
+OPENAI_API_KEY = config.OPENAI_API_KEY
+TV_USER = config.TV_USER
+TV_PASS = config.TV_PASS
 
 # Banner Responsive
 def tampilkan_banner():


### PR DESCRIPTION
## Summary
- add `credentials.py` for saving/loading API keys and TradingView login
- use credentials in `config.py` and prompt for missing info if needed
- allow updating saved credentials via `--configure` flag in `main.py`
- document new setup workflow in `README.md`

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684d3f1d12d083229121356c6c1b9f9b