### PR TITLE
Ubah flow autentikasi ke login akun OpenAI langsung

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,20 +50,21 @@ python main.py --configure
 ```
 Perintah di atas akan menanyakan `TV_USER` dan `TV_PASS` lalu menyimpannya ke file `credentials.json`.
 
-Saat menjalankan bot, login AI menggunakan `CODEX_OAUTH_TOKEN` (OAuth access token Codex/OpenAI), bukan API key.
+Saat menjalankan bot, program akan **login akun OpenAI langsung** lewat OAuth (bukan minta input access token manual).
 
-Untuk OAuth Login otomatis (authorization code flow), siapkan environment variable berikut:
+Siapkan kredensial OAuth app berikut (via environment variable atau isi saat prompt pertama kali):
 - `OPENAI_OAUTH_CLIENT_ID`
 - `OPENAI_OAUTH_CLIENT_SECRET`
 - `OPENAI_OAUTH_REDIRECT_URI`
 
-Jika ketiganya tersedia, bot akan:
+Flow login di program:
 1. Menampilkan URL login OAuth (`https://auth.openai.com/oauth/authorize`)
-2. Meminta authorization code / redirect URL
-3. Menukar code ke token di endpoint (`https://auth.openai.com/oauth/token`)
-4. Menyimpan `access_token`, `refresh_token`, dan waktu expired ke `credentials.json`
+2. Anda login akun OpenAI di browser dan menyetujui akses
+3. Paste authorization code / redirect URL ke terminal
+4. Bot menukar code ke token di endpoint (`https://auth.openai.com/oauth/token`)
+5. Bot menyimpan `access_token`, `refresh_token`, dan waktu expired ke `credentials.json`
 
-Setelah refresh token tersimpan, bot juga akan mencoba auto-refresh access token secara otomatis pada run berikutnya.
+Pada run berikutnya, bot akan mencoba auto-refresh access token menggunakan refresh token yang tersimpan.
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -166,12 +166,42 @@ def get_saved_oauth_token(credentials):
     return ''
 
 
+def ensure_oauth_config(credentials):
+    oauth_client_id = os.getenv('OPENAI_OAUTH_CLIENT_ID') or credentials.get('OPENAI_OAUTH_CLIENT_ID', '')
+    oauth_client_secret = os.getenv('OPENAI_OAUTH_CLIENT_SECRET') or credentials.get('OPENAI_OAUTH_CLIENT_SECRET', '')
+    oauth_redirect_uri = os.getenv('OPENAI_OAUTH_REDIRECT_URI') or credentials.get('OPENAI_OAUTH_REDIRECT_URI', '')
+
+    missing_fields = []
+    if not oauth_client_id:
+        missing_fields.append('OPENAI_OAUTH_CLIENT_ID')
+    if not oauth_client_secret:
+        missing_fields.append('OPENAI_OAUTH_CLIENT_SECRET')
+    if not oauth_redirect_uri:
+        missing_fields.append('OPENAI_OAUTH_REDIRECT_URI')
+
+    if missing_fields:
+        print('\n🔐 Konfigurasi OAuth OpenAI belum lengkap.')
+        print('Masukkan detail OAuth app agar bisa login akun OpenAI langsung dari program.')
+
+        if not oauth_client_id:
+            oauth_client_id = input('OPENAI_OAUTH_CLIENT_ID: ').strip()
+        if not oauth_client_secret:
+            oauth_client_secret = input('OPENAI_OAUTH_CLIENT_SECRET: ').strip()
+        if not oauth_redirect_uri:
+            oauth_redirect_uri = input('OPENAI_OAUTH_REDIRECT_URI: ').strip()
+
+        credentials['OPENAI_OAUTH_CLIENT_ID'] = oauth_client_id
+        credentials['OPENAI_OAUTH_CLIENT_SECRET'] = oauth_client_secret
+        credentials['OPENAI_OAUTH_REDIRECT_URI'] = oauth_redirect_uri
+        save_credentials(credentials)
+
+    return oauth_client_id, oauth_client_secret, oauth_redirect_uri
+
+
 CODEX_OAUTH_TOKEN = os.getenv('CODEX_OAUTH_TOKEN') or os.getenv('CODEX_TOKEN') or get_saved_oauth_token(creds)
 
 if not CODEX_OAUTH_TOKEN:
-    oauth_client_id = os.getenv('OPENAI_OAUTH_CLIENT_ID') or creds.get('OPENAI_OAUTH_CLIENT_ID')
-    oauth_client_secret = os.getenv('OPENAI_OAUTH_CLIENT_SECRET') or creds.get('OPENAI_OAUTH_CLIENT_SECRET')
-    oauth_redirect_uri = os.getenv('OPENAI_OAUTH_REDIRECT_URI') or creds.get('OPENAI_OAUTH_REDIRECT_URI')
+    oauth_client_id, oauth_client_secret, oauth_redirect_uri = ensure_oauth_config(creds)
     oauth_refresh_token = os.getenv('OPENAI_REFRESH_TOKEN') or creds.get('OPENAI_REFRESH_TOKEN')
 
     if oauth_client_id and oauth_client_secret and oauth_refresh_token:
@@ -186,7 +216,7 @@ if not CODEX_OAUTH_TOKEN:
 
     if not CODEX_OAUTH_TOKEN and oauth_client_id and oauth_client_secret and oauth_redirect_uri:
         auth_url = build_oauth_authorize_url(oauth_client_id, oauth_redirect_uri)
-        print('\n🔐 Login OAuth OpenAI diperlukan untuk melanjutkan.')
+        print('\n🔐 Login akun OpenAI diperlukan untuk melanjutkan.')
         print('1) Buka URL berikut di browser, login, lalu izinkan akses aplikasi:')
         print(auth_url)
         raw_code = input('2) Paste authorization code (atau URL redirect penuh): ').strip()
@@ -203,7 +233,7 @@ if not CODEX_OAUTH_TOKEN:
                 save_oauth_tokens(creds, token_response)
                 CODEX_OAUTH_TOKEN = token_response.get('access_token', '')
                 if CODEX_OAUTH_TOKEN:
-                    print('✅ OAuth login berhasil. Access token sudah tersimpan.')
+                    print('✅ Login akun OpenAI berhasil. Access token sudah tersimpan otomatis.')
             except error.HTTPError as http_error:
                 detail = http_error.read().decode('utf-8', errors='ignore')
                 print(f'❌ OAuth token exchange gagal: {detail or http_error.reason}')
@@ -211,13 +241,7 @@ if not CODEX_OAUTH_TOKEN:
                 print(f'❌ OAuth token exchange gagal: {exc}')
 
 if not CODEX_OAUTH_TOKEN:
-    CODEX_OAUTH_TOKEN = input('CODEX_OAUTH_TOKEN (OAuth access token): ').strip()
-    if CODEX_OAUTH_TOKEN:
-        creds['CODEX_OAUTH_TOKEN'] = CODEX_OAUTH_TOKEN
-        save_credentials(creds)
-
-if not CODEX_OAUTH_TOKEN:
-    print('❌ CODEX_OAUTH_TOKEN belum diisi. Silakan login Codex/OpenAI dan masukkan OAuth token Anda.')
+    print('❌ Login akun OpenAI gagal. Pastikan OAuth app valid dan ulangi proses login.')
     sys.exit(1)
 
 client = OpenAI(api_key=CODEX_OAUTH_TOKEN)


### PR DESCRIPTION
### Motivation
- Memperbaiki alur autentikasi agar program melakukan login akun OpenAI via OAuth (authorization code flow) daripada meminta input manual `CODEX_OAUTH_TOKEN` dari pengguna.
- Memudahkan UX dan memungkinkan auto-refresh token menggunakan `OPENAI_REFRESH_TOKEN` yang tersimpan.
- Menghindari penyimpanan/pengetikan akses token secara manual untuk alasan keamanan dan kenyamanan.

### Description
- Menambahkan helper `ensure_oauth_config` untuk meminta dan menyimpan `OPENAI_OAUTH_CLIENT_ID`, `OPENAI_OAUTH_CLIENT_SECRET`, dan `OPENAI_OAUTH_REDIRECT_URI` jika belum tersedia.
- Menghapus fallback input manual `CODEX_OAUTH_TOKEN` dan mengarahkan alur ke OAuth authorization code flow dengan pembuatan URL `https://auth.openai.com/oauth/authorize` dan penukaran kode di `https://auth.openai.com/oauth/token`.
- Tetap mempertahankan mekanisme refresh token dengan `refresh_oauth_token` dan penyimpanan token hasil refresh ke `credentials.json`.
- Memperbarui teks dokumentasi di `README.md` agar menjelaskan flow login akun OpenAI langsung melalui OAuth.

### Testing
- Menjalankan pemeriksaan sintaks Python dengan `python -m py_compile main.py credentials.py config.py`, dan pemeriksaan ini berhasil tanpa error.
- Tidak ada tes unit tambahan otomatis; perubahan diuji statis untuk memastikan file Python tercompile dengan benar.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b55323611c8322af4c965157143743)